### PR TITLE
Add NinjaTrader 8 adapter bridge

### DIFF
--- a/src/nt8-adapter/EntropyBar.cs
+++ b/src/nt8-adapter/EntropyBar.cs
@@ -1,0 +1,21 @@
+// src/nt8-adapter/EntropyBar.cs
+using System;
+
+namespace IMM.NT8
+{
+    public struct EntropyBar
+    {
+        public string Symbol;
+        public DateTime Timestamp;
+        public double Open, High, Low, Close, Volume;
+        public double DeltaPhi;    // entropy proxy (e.g., ATR/Close or your Shannon)
+        public string Regime;      // "P" | "INTERMEDIATE" | "NP"
+        public string CapsuleId;   // session capsule lineage id
+    }
+
+    public static class EntropyMath
+    {
+        public static string RegimeOf(double dphi) =>
+            dphi < 0.045 ? "P" : dphi >= 0.09 ? "NP" : "INTERMEDIATE";
+    }
+}

--- a/src/nt8-adapter/EntropyEchoDriftSentinel_Adapter.cs
+++ b/src/nt8-adapter/EntropyEchoDriftSentinel_Adapter.cs
@@ -1,0 +1,81 @@
+// src/nt8-adapter/EntropyEchoDriftSentinel_Adapter.cs
+#region Using
+using System;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using NinjaTrader.NinjaScript.Indicators;
+#endregion
+
+namespace IMM.NT8
+{
+    public class EntropyEchoDriftSentinel_Adapter : IMMAdapterStrategyBase
+    {
+        [NinjaScriptProperty, Range(0.5, 0.95)]
+        [Display(Name="Base Conviction Threshold", GroupName="Conviction", Order=1)]
+        public double BaseConvictionThreshold { get; set; } = 0.75;
+
+        private EMA emaFast, emaSlow;
+        private RSI rsi;
+
+        protected override void OnStateChange()
+        {
+            base.OnStateChange();
+            if (State == State.DataLoaded)
+            {
+                emaFast = EMA(10);
+                emaSlow = EMA(40);
+                rsi = RSI(14, 3);
+                AddChartIndicator(emaFast);
+                AddChartIndicator(emaSlow);
+            }
+        }
+
+        protected override void OnBarUpdate()
+        {
+            if (CurrentBar < BarsRequiredToTrade) return;
+
+            // Build entropy bar & quick features
+            var eb = MakeEntropyBar();
+            bool trendAlignedLong = emaFast[0] > emaSlow[0];
+            bool trendAlignedShort = emaFast[0] < emaSlow[0];
+            double rsiNeutrality = 1.0 - Math.Min(1.0, Math.Abs(rsi[0] - 50) / 50.0);
+            double dynConv = 0.35 * rsiNeutrality + 0.65 * Math.Min(1.0, Math.Abs(emaFast[0] - emaSlow[0]) / (atr[0] * 2.0));
+
+            // regime gate (skip NP)
+            bool regimeOK = eb.Regime != "NP";
+
+            // decide
+            string glyph = "Hermit_Defer";
+            string decision = "Hold";
+
+            if (regimeOK && dynConv >= BaseConvictionThreshold)
+            {
+                if (trendAlignedLong && Position.MarketPosition == MarketPosition.Flat)
+                {
+                    glyph = "StrongBloom_*";
+                    decision = "EnterLong";
+                    EnterLong(1, "EEDS_Long");
+                    LedgerEnter("LONG", Close[0]);
+                }
+                else if (trendAlignedShort && Position.MarketPosition == MarketPosition.Flat)
+                {
+                    glyph = "StrongBloom_*";
+                    decision = "EnterShort";
+                    EnterShort(1, "EEDS_Short");
+                    LedgerEnter("SHORT", Close[0]);
+                }
+            }
+
+            // emit capsule line once per bar
+            proof.WriteCapsule(eb, glyph, decision, dynConv, regimeOK, trendAlignedLong || trendAlignedShort);
+
+            // simple protective exit if RSI flips hard
+            if (Position.MarketPosition == MarketPosition.Long && rsi[0] < 45)
+                ExitLong("RSIFlipExit", "EEDS_Long");
+            if (Position.MarketPosition == MarketPosition.Short && rsi[0] > 55)
+                ExitShort("RSIFlipExit", "EEDS_Short");
+
+            if (CurrentBar % 50 == 0) proof.Flush();
+        }
+    }
+}

--- a/src/nt8-adapter/IMMAdapterStrategyBase.cs
+++ b/src/nt8-adapter/IMMAdapterStrategyBase.cs
@@ -1,0 +1,82 @@
+// src/nt8-adapter/IMMAdapterStrategyBase.cs
+#region Using
+using System;
+using NinjaTrader.Cbi;
+using NinjaTrader.NinjaScript;
+using NinjaTrader.NinjaScript.Indicators;
+#endregion
+
+namespace IMM.NT8
+{
+    public abstract class IMMAdapterStrategyBase : Strategy
+    {
+        // lightweight signals
+        protected ATR atr;
+        protected double dphi; // entropy proxy
+        protected string regime;
+        protected IMMBridgeClient bridge;
+        protected ProofBridgeLogger proof;
+
+        protected override void OnStateChange()
+        {
+            if (State == State.SetDefaults)
+            {
+                Calculate = Calculate.OnBarClose;
+                BarsRequiredToTrade = 50;
+                Name = "IMMAdapterBase";
+            }
+            else if (State == State.DataLoaded)
+            {
+                atr = ATR(14);
+                var cfg = IMMConfig.LoadOrDefault();
+                bridge = new IMMBridgeClient(cfg);
+                proof = new ProofBridgeLogger(this, bridge);
+            }
+        }
+
+        protected EntropyBar MakeEntropyBar()
+        {
+            dphi = (Close[0] > 0 ? atr[0] / Close[0] : 0.0);
+            regime = EntropyMath.RegimeOf(dphi);
+            return new EntropyBar
+            {
+                Symbol = Instrument.MasterInstrument.Name,
+                Timestamp = Time[0],
+                Open = Open[0], High = High[0], Low = Low[0], Close = Close[0],
+                Volume = Volume[0],
+                DeltaPhi = dphi,
+                Regime = regime,
+                CapsuleId = "SESSION⇌" + TradingHours?.Name ?? "RTH"
+            };
+        }
+
+        protected void LedgerEnter(string name, double price)
+        {
+            proof.WriteLedger(Time[0], Instrument.MasterInstrument.Name, $"ENTER_{name}", price, dphi, regime, 0.0);
+        }
+
+        protected void LedgerExit(string reason, double price, double realized)
+        {
+            proof.WriteLedger(Time[0], Instrument.MasterInstrument.Name, $"EXIT_{reason}", price, dphi, regime, realized);
+        }
+
+        protected override void OnExecutionUpdate(Execution exec, string id, double price, int qty, MarketPosition mp, string orderId, DateTime t)
+        {
+            if (exec?.Order == null || exec.Order.OrderState != OrderState.Filled) return;
+
+            // If we just flattened, compute realized and log
+            if (Position.MarketPosition == MarketPosition.Flat)
+            {
+                var trades = SystemPerformance.AllTrades;
+                double realized = trades.Count > 0 ? trades[trades.Count - 1].ProfitCurrency : 0.0;
+                LedgerExit("FLAT", price, realized);
+            }
+        }
+
+        protected override void OnTermination()
+        {
+            proof?.Flush();
+            base.OnTermination();
+        }
+    }
+}

--- a/src/nt8-adapter/IMMBridgeClient.cs
+++ b/src/nt8-adapter/IMMBridgeClient.cs
@@ -1,0 +1,113 @@
+// src/nt8-adapter/IMMBridgeClient.cs
+using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace IMM.NT8
+{
+    public interface IBridgeSink
+    {
+        void WriteJsonLine(object o);
+        void WriteCsvLine(string csv);
+        void Flush();
+    }
+
+    public sealed class FileSink : IBridgeSink
+    {
+        private readonly string ndjsonFile;
+        private readonly string csvFile;
+        private readonly bool writeCsv;
+
+        public FileSink(string ndjsonDir, string csvPath, bool writeCsvLedger)
+        {
+            Directory.CreateDirectory(ndjsonDir);
+            ndjsonFile = Path.Combine(ndjsonDir, $"cog_{DateTime.UtcNow:yyyyMMdd}.ndjson");
+            csvFile = csvPath;
+            writeCsv = writeCsvLedger;
+
+            if (writeCsv && !File.Exists(csvFile))
+                File.WriteAllText(csvFile, "timestamp,capsule_id,action,price,delta_phi,regime,realized\n");
+        }
+
+        public void WriteJsonLine(object o)
+        {
+            var line = JsonConvert.SerializeObject(o);
+            File.AppendAllText(ndjsonFile, line + "\n");
+        }
+
+        public void WriteCsvLine(string csv)
+        {
+            if (!writeCsv) return;
+            File.AppendAllText(csvFile, csv + "\n");
+        }
+
+        public void Flush() { /* file appends are durable per write */ }
+    }
+
+    public sealed class TcpSink : IBridgeSink
+    {
+        private readonly FileSink fallback;
+        private readonly bool enabled;
+        private TcpClient client;
+        private NetworkStream stream;
+
+        public TcpSink(FileSink fallback, bool enable, string host, int port)
+        {
+            this.fallback = fallback;
+            enabled = enable;
+            if (!enabled) return;
+            try
+            {
+                client = new TcpClient();
+                client.Connect(host, port);
+                stream = client.GetStream();
+            }
+            catch { enabled = false; /* fall back to file only */ }
+        }
+
+        public void WriteJsonLine(object o)
+        {
+            var line = JsonConvert.SerializeObject(o) + "\n";
+            if (enabled && stream != null && stream.CanWrite)
+            {
+                var bytes = Encoding.UTF8.GetBytes(line);
+                try { stream.Write(bytes, 0, bytes.Length); }
+                catch { /* drop to file */ fallback.WriteJsonLine(o); }
+            }
+            else fallback.WriteJsonLine(o);
+        }
+
+        public void WriteCsvLine(string csv)
+        {
+            var line = csv + "\n";
+            if (enabled && stream != null && stream.CanWrite)
+            {
+                var bytes = Encoding.UTF8.GetBytes(line);
+                try { stream.Write(bytes, 0, bytes.Length); }
+                catch { fallback.WriteCsvLine(csv); }
+            }
+            else fallback.WriteCsvLine(csv);
+        }
+
+        public void Flush()
+        {
+            try { stream?.Flush(); } catch { }
+        }
+    }
+
+    public sealed class IMMBridgeClient
+    {
+        private readonly IBridgeSink sink;
+        public IMMBridgeClient(IMMConfig cfg)
+        {
+            var fileSink = new FileSink(cfg.NdjsonPath, cfg.LedgerCsvPath, cfg.AlsoWriteCsvLedger);
+            sink = cfg.TcpEnabled ? new TcpSink(fileSink, true, cfg.TcpHost, cfg.TcpPort) : (IBridgeSink)fileSink;
+        }
+
+        public void EmitCapsule(dynamic capsule) => sink.WriteJsonLine(capsule);
+        public void EmitLedgerCsv(string csvLine) => sink.WriteCsvLine(csvLine);
+        public void Flush() => sink.Flush();
+    }
+}

--- a/src/nt8-adapter/IMMConfig.cs
+++ b/src/nt8-adapter/IMMConfig.cs
@@ -1,0 +1,39 @@
+// src/nt8-adapter/IMMConfig.cs
+using System;
+using System.IO;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace IMM.NT8
+{
+    public sealed class IMMConfig
+    {
+        public string NdjsonPath { get; set; } =
+            Path.Combine(NinjaTrader.Core.Globals.UserDataDir, "Capsules", "COG", "Oracle_v8");
+        public string LedgerCsvPath { get; set; } =
+            Path.Combine(NinjaTrader.Core.Globals.UserDataDir, "Proof", "trade_ledger.csv");
+        public bool AlsoWriteCsvLedger { get; set; } = true;
+
+        // Optional socket sink (disabled by default)
+        public bool TcpEnabled { get; set; } = false;
+        public string TcpHost { get; set; } = "127.0.0.1";
+        public int TcpPort { get; set; } = 5757;
+
+        public static IMMConfig LoadOrDefault(string path = null)
+        {
+            try
+            {
+                path ??= Path.Combine(NinjaTrader.Core.Globals.UserDataDir, "imm_nt8_config.json");
+                if (!File.Exists(path))
+                {
+                    var def = new IMMConfig();
+                    File.WriteAllText(path, JsonConvert.SerializeObject(def, Formatting.Indented));
+                    return def;
+                }
+                var json = File.ReadAllText(path);
+                return JsonConvert.DeserializeObject<IMMConfig>(json) ?? new IMMConfig();
+            }
+            catch { return new IMMConfig(); }
+        }
+    }
+}

--- a/src/nt8-adapter/ProofBridgeLogger.cs
+++ b/src/nt8-adapter/ProofBridgeLogger.cs
@@ -1,0 +1,43 @@
+// src/nt8-adapter/ProofBridgeLogger.cs
+using System;
+using System.Linq;
+using NinjaTrader.NinjaScript;
+
+namespace IMM.NT8
+{
+    public sealed class ProofBridgeLogger
+    {
+        private readonly Strategy strat;
+        private readonly IMMBridgeClient client;
+
+        public ProofBridgeLogger(Strategy s, IMMBridgeClient c) { strat = s; client = c; }
+
+        public void WriteCapsule(EntropyBar eb, string glyph, string decision, double dynConviction, bool regimeOK, bool trendAligned)
+        {
+            var capsule = new
+            {
+                capsule_id = "IMM⇌COGNITION⇌EchoThread_Oracle_v8.v3.7",
+                emitted_at = eb.Timestamp.ToString("o"),
+                symbol = eb.Symbol,
+                glyph,
+                decision,
+                regime_ok = regimeOK,
+                trend_aligned = trendAligned,
+                fractal_vol = eb.DeltaPhi,
+                dynamic_conviction = dynConviction,
+                last_trade_pnl = strat.SystemPerformance.AllTrades.Count > 0
+                    ? strat.SystemPerformance.AllTrades.Last().ProfitCurrency : 0.0
+            };
+            client.EmitCapsule(capsule);
+        }
+
+        public void WriteLedger(DateTime ts, string sym, string action, double price, double dphi, string regime, double realized)
+        {
+            string id = $"TRADE⇌{sym}⇌{new DateTimeOffset(ts).ToUnixTimeSeconds()}";
+            string line = $"{ts:O},{id},{action},{price},{dphi},{regime},{realized}";
+            client.EmitLedgerCsv(line);
+        }
+
+        public void Flush() => client.Flush();
+    }
+}

--- a/src/nt8-adapter/README.md
+++ b/src/nt8-adapter/README.md
@@ -1,0 +1,30 @@
+# NT8 Adapter (IMM Bridge)
+
+This folder contains a NinjaTrader 8 adapter that:
+- computes a lightweight entropy proxy (ΔΦ ≈ ATR/Close),
+- gates trades by regime (P/INTERMEDIATE/NP),
+- emits NDJSON capsules + optional CSV ledger (ProofBridge),
+- optionally streams JSONL over TCP to an external harness.
+
+Files:
+- IMMConfig.cs               — loads/writes adapter config
+- IMMBridgeClient.cs         — file/tcp sinks
+- EntropyBar.cs              — ΔΦ struct + regime map
+- ProofBridgeLogger.cs       — capsule + ledger writers
+- IMMAdapterStrategyBase.cs  — base class with logging & ledger hooks
+- EntropyEchoDriftSentinel_Adapter.cs — your strategy wired to the bridge
+
+Deploy:
+1) Open NT8 > New > NinjaScript Editor.
+2) Create a new folder `IMM.NT8` (namespace).
+3) Add each `.cs` file there and compile.
+4) In a chart, add `EntropyEchoDriftSentinel_Adapter` as a strategy.
+5) A config file `imm_nt8_config.json` will be created in your NT8 UserDataDir.
+6) Outputs:
+   - NDJSON:  `<UserData>/Capsules/COG/Oracle_v8/cog_YYYYMMDD.ndjson`
+   - CSV:     `<UserData>/Proof/trade_ledger.csv`
+7) For TCP streaming, set `"TcpEnabled": true` in the config and run your external listener.
+
+Notes:
+- Replace the ΔΦ proxy with your Shannon/bucketed entropy when ready.
+- The adapter is strategy-agnostic; inherit from `IMMAdapterStrategyBase` to wire other builds.


### PR DESCRIPTION
## Summary
- add NinjaTrader IMM adapter configuration, bridge sinks, and proof logger helpers
- provide a reusable strategy base class that builds entropy bars and writes ledger entries
- implement the EntropyEchoDriftSentinel adapter strategy and accompanying documentation for deployment

## Testing
- not run (NinjaTrader strategy code)


------
https://chatgpt.com/codex/tasks/task_e_68cd9fb01ad48320af0fd5a2badeebea