### PR TITLE
Add baseline simulation engine and strategy pack

### DIFF
--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -1,0 +1,28 @@
+# scripts/run_backtest.py
+from __future__ import annotations
+import argparse
+import importlib
+import json
+from pathlib import Path
+import pandas as pd
+from sim.engine import run_once
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bars", required=True, type=Path, help="CSV with columns: timestamp,open,high,low,close,volume")
+    ap.add_argument("--strategy", required=True, help="e.g. strategies.sentient_spire_v12:SentientSpireV12")
+    ap.add_argument("--report", required=True, type=Path, help="Output JSON path")
+    args = ap.parse_args()
+
+    df = pd.read_csv(args.bars)
+    module_name, class_name = args.strategy.split(":")
+    Strat = getattr(importlib.import_module(module_name), class_name)
+    strat = Strat()
+
+    result = run_once(df, strat)
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.report.write_text(json.dumps(result, indent=2))
+    print(f"✅ wrote {args.report}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_mc.py
+++ b/scripts/run_mc.py
@@ -1,0 +1,33 @@
+# scripts/run_mc.py
+from __future__ import annotations
+import argparse
+import importlib
+import json
+from pathlib import Path
+import pandas as pd
+from sim.monte_carlo import run_mc
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bars", required=True, type=Path)
+    ap.add_argument("--strategy", required=True, help="e.g. strategies.sentient_spire_v12:SentientSpireV12")
+    ap.add_argument("--runs", type=int, default=200)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--price_bps", type=float, default=0.0, help="Gaussian price jitter sigma in bps")
+    ap.add_argument("--slippage_ticks", type=float, default=1.0)
+    ap.add_argument("--report", required=True, type=Path)
+    args = ap.parse_args()
+
+    df = pd.read_csv(args.bars)
+    mod, cls = args.strategy.split(":")
+    Strat = getattr(importlib.import_module(mod), cls)
+    def ctor():
+        return Strat()
+
+    summary = run_mc(df, ctor, runs=args.runs, seed=args.seed, price_bps=args.price_bps, slippage_ticks=args.slippage_ticks)
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.report.write_text(json.dumps(summary, indent=2))
+    print(f"✅ wrote {args.report}")
+
+if __name__ == "__main__":
+    main()

--- a/sim/__init__.py
+++ b/sim/__init__.py
@@ -1,0 +1,7 @@
+"""Simulation utilities for predictive market engine."""
+
+__all__ = [
+    "engine",
+    "metrics",
+    "monte_carlo",
+]

--- a/sim/engine.py
+++ b/sim/engine.py
@@ -1,0 +1,197 @@
+# sim/engine.py
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional, Dict, Any
+import pandas as pd
+import numpy as np
+from .metrics import daily_roi_df, equity_stats
+
+# --- simple indicators (vectorized) ---
+def ema(s: pd.Series, n: int) -> pd.Series:
+    return s.ewm(span=n, adjust=False).mean()
+
+def rsi(close: pd.Series, n: int = 14) -> pd.Series:
+    delta = close.diff()
+    up = (delta.where(delta > 0, 0)).rolling(n).mean()
+    down = (-delta.where(delta < 0, 0)).rolling(n).mean()
+    rs = up / (down.replace(0, np.nan))
+    out = 100 - (100 / (1 + rs))
+    return out.fillna(50.0)
+
+def atr(df: pd.DataFrame, n: int = 14) -> pd.Series:
+    high, low, close = df["high"], df["low"], df["close"]
+    prev_close = close.shift(1)
+    tr = pd.concat(
+        [
+            (high - low),
+            (high - prev_close).abs(),
+            (low - prev_close).abs(),
+        ],
+        axis=1,
+    ).max(axis=1)
+    return tr.rolling(n).mean()
+
+# --- broker model (very small, close-to-close fills) ---
+@dataclass
+class Position:
+    qty: int = 0
+    avg_price: float = 0.0
+
+class Broker:
+    def __init__(self, cash: float, commission_per_contract: float = 2.0, slippage_ticks: float = 1.0, tick_value: float = 12.5, tick_size: float = 0.25):
+        self.cash = float(cash)
+        self.equity = float(cash)
+        self.pos = Position()
+        self.commission = commission_per_contract
+        self.slip_ticks = slippage_ticks
+        self.tick_value = tick_value
+        self.tick_size = tick_size
+        self.trades: list[dict] = []
+        self._equity_curve: list[tuple[pd.Timestamp, float]] = []
+
+    def _slip_price(self, px: float, side: str) -> float:
+        slip = self.slip_ticks * self.tick_size
+        return px + (slip if side == "BUY" else -slip)
+
+    def mark(self, ts: pd.Timestamp, last_price: float):
+        # mark-to-market equity
+        if self.pos.qty != 0:
+            pnl_per = (last_price - self.pos.avg_price) * np.sign(self.pos.qty)
+            position_value = pnl_per * abs(self.pos.qty) * (self.tick_value / self.tick_size)
+        else:
+            position_value = 0.0
+        self.equity = self.cash + position_value
+        self._equity_curve.append((ts, self.equity))
+
+    def buy(self, ts: pd.Timestamp, px: float, qty: int):
+        fill_px = self._slip_price(px, "BUY")
+        fees = self.commission * qty
+        dollar_mult = (self.tick_value / self.tick_size)
+        # adjust avg
+        new_qty = self.pos.qty + qty
+        if self.pos.qty == 0:
+            new_avg = fill_px
+        else:
+            new_avg = (self.pos.avg_price * self.pos.qty + fill_px * qty) / new_qty
+        self.pos = Position(qty=new_qty, avg_price=new_avg)
+        self.cash -= fees
+        self.trades.append({"ts": ts, "side": "BUY", "qty": qty, "price": fill_px, "fees": fees, "mult": dollar_mult})
+
+    def sell(self, ts: pd.Timestamp, px: float, qty: int):
+        fill_px = self._slip_price(px, "SELL")
+        fees = self.commission * qty
+        dollar_mult = (self.tick_value / self.tick_size)
+        # close or reduce long
+        realized = 0.0
+        if self.pos.qty > 0:
+            close_qty = min(qty, self.pos.qty)
+            realized = (fill_px - self.pos.avg_price) * close_qty * dollar_mult
+            self.pos.qty -= close_qty
+        else:
+            # shorting not implemented in first pack; keep long-only
+            pass
+        self.cash += realized - fees
+        self.trades.append({"ts": ts, "side": "SELL", "qty": qty, "price": fill_px, "fees": fees, "realized": realized, "mult": dollar_mult})
+
+    @property
+    def equity_curve(self) -> pd.Series:
+        if not self._equity_curve:
+            return pd.Series(dtype=float)
+        idx = pd.to_datetime([t for t, _ in self._equity_curve], utc=True)
+        val = [v for _, v in self._equity_curve]
+        return pd.Series(val, index=idx).sort_index()
+
+# --- Strategy contract (imported at runtime) ---
+class Context:
+    def __init__(self, cash: float, position_qty: int, position_avg: Optional[float], day_pnl: float, realized_dd_pct: float, regime: str):
+        self.cash = cash
+        self.position_qty = position_qty
+        self.position_avg = position_avg
+        self.day_pnl = day_pnl
+        self.realized_dd_pct = realized_dd_pct
+        self.regime = regime
+
+def classify_regime(atr_to_close: float) -> str:
+    if atr_to_close < 0.005:
+        return "Calm"
+    if atr_to_close < 0.010:
+        return "Fractal"
+    return "Cascade"
+
+def run_once(
+    bars: pd.DataFrame,
+    strategy_obj: Any,
+    cash: float = 100_000.0,
+    commission: float = 2.0,
+    slippage_ticks: float = 1.0,
+    rsi_period: int = 14,
+    ema_fast: int = 20,
+    ema_slow: int = 50,
+    atr_period: int = 14,
+) -> dict:
+    """
+    bars: DataFrame with columns [timestamp, open, high, low, close, volume]
+          utc timestamps expected
+    strategy_obj: instance implementing .on_bar(df_row, ctx) -> list[OrderDict]
+    """
+    df = bars.copy()
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+    df = df.sort_values("timestamp").reset_index(drop=True)
+    # indicators
+    df["ema_fast"] = ema(df["close"], ema_fast)
+    df["ema_slow"] = ema(df["close"], ema_slow)
+    df["rsi"] = rsi(df["close"], rsi_period)
+    df["atr"] = atr(df[["high", "low", "close"]], atr_period)
+    df["atr_to_close"] = df["atr"] / df["close"]
+    # broker
+    broker = Broker(cash=cash, commission_per_contract=commission, slippage_ticks=slippage_ticks)
+    day_start_equity = cash
+    peak_equity = cash
+
+    for i, row in df.iterrows():
+        ts = row["timestamp"]
+        regime = classify_regime(row["atr_to_close"]) if pd.notna(row["atr_to_close"]) else "Calm"
+        broker.mark(ts, float(row["close"]))
+
+        # session/day tracking
+        date = ts.date()
+        if i == 0 or df.loc[i - 1, "timestamp"].date() != date:
+            day_start_equity = broker.equity
+        peak_equity = max(peak_equity, broker.equity)
+        dd_pct = 0.0 if peak_equity == 0 else max(0.0, (peak_equity - broker.equity) / peak_equity * 100.0)
+
+        ctx = Context(
+            cash=broker.cash,
+            position_qty=broker.pos.qty,
+            position_avg=None if broker.pos.qty == 0 else broker.pos.avg_price,
+            day_pnl=broker.equity - day_start_equity,
+            realized_dd_pct=dd_pct,
+            regime=regime,
+        )
+
+        # delegate to strategy (expects dict orders: {'side': 'BUY'|'SELL', 'qty': int})
+        orders: list[dict] = strategy_obj.on_bar(row, ctx) or []
+        for od in orders:
+            side = od.get("side")
+            qty = int(max(0, od.get("qty", 0)))
+            if qty <= 0:
+                continue
+            if side == "BUY":
+                broker.buy(ts, float(row["close"]), qty)
+            elif side == "SELL":
+                broker.sell(ts, float(row["close"]), qty)
+
+    equity = broker.equity_curve
+    daily = daily_roi_df(equity)
+    stats = equity_stats(equity)
+
+    return {
+        "daily": daily.to_dict(orient="records"),
+        "summary": stats,
+        "meta": {
+            "bars": len(df),
+            "start": df["timestamp"].iloc[0].isoformat(),
+            "end": df["timestamp"].iloc[-1].isoformat(),
+            "strategy": getattr(strategy_obj, "name", "Unknown"),
+        },
+    }

--- a/sim/metrics.py
+++ b/sim/metrics.py
@@ -1,0 +1,52 @@
+# sim/metrics.py
+from __future__ import annotations
+import numpy as np
+import pandas as pd
+
+def daily_roi_df(equity: pd.Series) -> pd.DataFrame:
+    eq = equity.dropna()
+    if eq.empty:
+        return pd.DataFrame(columns=["date", "roi_pct", "pnl"])
+    daily = eq.resample("1D").last().dropna()
+    roi = daily.pct_change().fillna(0.0) * 100.0
+    pnl = daily.diff().fillna(0.0)
+    return pd.DataFrame({"date": daily.index.date, "roi_pct": roi.values, "pnl": pnl.values})
+
+def max_drawdown_pct(equity: pd.Series) -> float:
+    eq = equity.dropna()
+    if eq.empty:
+        return 0.0
+    run_max = eq.cummax()
+    dd = (eq / run_max - 1.0).min()
+    return float(abs(dd) * 100.0)
+
+def sharpe_daily(equity: pd.Series, rf: float = 0.0) -> float:
+    ret = equity.pct_change().dropna()
+    if ret.std() == 0 or ret.empty:
+        return 0.0
+    ex = ret - rf / 252.0
+    return float(np.sqrt(252) * ex.mean() / ex.std())
+
+def calmar(equity: pd.Series) -> float:
+    eq = equity.dropna()
+    if len(eq) < 2:
+        return 0.0
+    total_ret = eq.iloc[-1] / eq.iloc[0] - 1.0
+    years = max(1e-9, len(eq) / (252 * 24 * 60))  # crude if minute bars; safe fallback
+    cagr = (1.0 + total_ret) ** (1.0 / years) - 1.0 if years > 0 else 0.0
+    mdd = max_drawdown_pct(eq) / 100.0
+    return 0.0 if mdd == 0 else float(cagr / mdd)
+
+def equity_stats(equity: pd.Series) -> dict:
+    daily = daily_roi_df(equity)
+    win_rate = float((daily["roi_pct"] > 0).mean()) if not daily.empty else 0.0
+    stats = {
+        "median_daily_roi_pct": float(daily["roi_pct"].median() if not daily.empty else 0.0),
+        "p05_daily_roi_pct": float(np.percentile(daily["roi_pct"], 5) if not daily.empty else 0.0),
+        "p95_daily_roi_pct": float(np.percentile(daily["roi_pct"], 95) if not daily.empty else 0.0),
+        "max_drawdown_pct": max_drawdown_pct(equity),
+        "sharpe": sharpe_daily(equity),
+        "calmar": calmar(equity),
+        "win_rate": win_rate,
+    }
+    return stats

--- a/sim/monte_carlo.py
+++ b/sim/monte_carlo.py
@@ -1,0 +1,55 @@
+# sim/monte_carlo.py
+from __future__ import annotations
+from typing import Callable
+import numpy as np
+import pandas as pd
+from .engine import run_once
+
+def perturb_bars(bars: pd.DataFrame, rng: np.random.Generator, price_bps: float = 0.0) -> pd.DataFrame:
+    if price_bps <= 0:
+        return bars
+    jitter = 1.0 + rng.normal(0.0, price_bps / 10_000.0, size=len(bars))
+    df = bars.copy()
+    for col in ("open", "high", "low", "close"):
+        df[col] = (df[col].to_numpy() * jitter).astype(float)
+    return df
+
+def run_mc(
+    bars: pd.DataFrame,
+    strategy_ctor: Callable[[], object],
+    runs: int = 200,
+    seed: int = 42,
+    price_bps: float = 0.0,
+    slippage_ticks: float = 1.0,
+) -> dict:
+    rng = np.random.default_rng(seed)
+    summaries = []
+    for _ in range(runs):
+        dfp = perturb_bars(bars, rng, price_bps=price_bps)
+        strat = strategy_ctor()
+        res = run_once(
+            dfp,
+            strat,
+            slippage_ticks=slippage_ticks * max(0.5, rng.normal(1.0, 0.1)),
+        )
+        summaries.append(res["summary"])
+
+    # Aggregate: median/p05/p95 daily ROI from summaries that carry per-day stats
+    med = np.median([s["median_daily_roi_pct"] for s in summaries])
+    p05 = np.percentile([s["median_daily_roi_pct"] for s in summaries], 5)
+    p95 = np.percentile([s["median_daily_roi_pct"] for s in summaries], 95)
+    max_dd = float(np.max([s["max_drawdown_pct"] for s in summaries]))
+    win = float(np.mean([s["win_rate"] for s in summaries]))
+    calmar = float(np.median([s["calmar"] for s in summaries]))
+
+    return {
+        "summary": {
+            "median_daily_roi_pct": float(med),
+            "p05_daily_roi_pct": float(p05),
+            "p95_daily_roi_pct": float(p95),
+            "max_drawdown_pct": max_dd,
+            "win_rate": win,
+            "calmar": calmar,
+            "runs": runs,
+        }
+    }

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,0 +1,6 @@
+"""Strategy implementations for the predictive market engine."""
+
+__all__ = [
+    "base",
+    "sentient_spire_v12",
+]

--- a/strategies/base.py
+++ b/strategies/base.py
@@ -1,0 +1,26 @@
+# strategies/base.py
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional, List, Dict, Any
+
+@dataclass
+class Context:
+    cash: float
+    position_qty: int
+    position_avg: Optional[float]
+    day_pnl: float
+    realized_dd_pct: float
+    regime: str
+
+class Strategy:
+    name = "BaseStrategy"
+
+    def on_bar(self, bar_row: Any, ctx: Context) -> List[Dict[str, Any]]:
+        """
+        Return a list of order dicts:
+          {'side': 'BUY'|'SELL', 'qty': int}
+        """
+        return []
+
+    def parameters(self) -> dict:
+        return {}

--- a/strategies/sentient_spire_v12.py
+++ b/strategies/sentient_spire_v12.py
@@ -1,0 +1,58 @@
+# strategies/sentient_spire_v12.py
+from __future__ import annotations
+from typing import List, Dict, Any
+from .base import Strategy, Context
+
+class SentientSpireV12(Strategy):
+    """
+    Lean variant of your Echo/Conviction idea:
+    - Long-only, trend-aligned (EMA fast>slow) & RSI>55
+    - Exit when RSI<45 or regime turns 'Cascade'
+    - Risk % sizing against ATR stop distance
+    """
+    name = "SentientSpire_v12"
+
+    def __init__(self, risk_pct: float = 0.015, stop_atr_mult: float = 1.5, target_r: float = 2.2):
+        self.risk_pct = risk_pct
+        self.stop_atr_mult = stop_atr_mult
+        self.target_r = target_r
+
+    def on_bar(self, bar_row, ctx: Context) -> List[Dict[str, Any]]:
+        if ctx.regime == "Cascade":
+            # de-risk: exit if in market
+            if ctx.position_qty > 0:
+                return [{"side": "SELL", "qty": ctx.position_qty}]
+            return []
+
+        ema_fast = float(bar_row.get("ema_fast", 0))
+        ema_slow = float(bar_row.get("ema_slow", 0))
+        rsi = float(bar_row.get("rsi", 50))
+        atr = float(bar_row.get("atr", 0.5))
+        close = float(bar_row["close"])
+
+        orders: List[Dict[str, Any]] = []
+
+        # Exit rule
+        if ctx.position_qty > 0 and rsi < 45:
+            orders.append({"side": "SELL", "qty": ctx.position_qty})
+            return orders
+
+        # Entry rule
+        trend_ok = ema_fast > ema_slow
+        if trend_ok and rsi > 55 and ctx.position_qty == 0 and atr > 0:
+            # position size = risk $ / (stop_distance $)
+            stop_dist_px = self.stop_atr_mult * atr
+            dollar_per_point = 50.0  # configurable per symbol if needed
+            risk_cash = ctx.cash * self.risk_pct
+            qty = int(max(1, risk_cash / (stop_dist_px * dollar_per_point)))
+            if qty > 0:
+                orders.append({"side": "BUY", "qty": qty})
+
+        return orders
+
+    def parameters(self) -> dict:
+        return {
+            "risk_pct": self.risk_pct,
+            "stop_atr_mult": self.stop_atr_mult,
+            "target_r": self.target_r,
+        }


### PR DESCRIPTION
## Summary
- add a vectorized backtest engine with simple indicators, broker model, and regime-aware context helpers
- provide ROI and risk metric utilities plus a Monte Carlo harness for perturbation analysis
- include a base strategy contract, a sample SentientSpire implementation, and CLI scripts for running backtests and MC sweeps

## Testing
- python -m pytest


------
https://chatgpt.com/codex/tasks/task_e_68cdaea86f048320818c8ede23c98c8c