### PR TITLE
Fix Ruff lint issues in strategies and sim utilities

### DIFF
--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -1,16 +1,29 @@
 # scripts/run_backtest.py
 from __future__ import annotations
+
 import argparse
 import importlib
 import json
 from pathlib import Path
+
 import pandas as pd
+
 from sim.engine import run_once
+
 
 def main() -> None:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--bars", required=True, type=Path, help="CSV with columns: timestamp,open,high,low,close,volume")
-    ap.add_argument("--strategy", required=True, help="e.g. strategies.sentient_spire_v12:SentientSpireV12")
+    ap.add_argument(
+        "--bars",
+        required=True,
+        type=Path,
+        help="CSV with columns: timestamp,open,high,low,close,volume",
+    )
+    ap.add_argument(
+        "--strategy",
+        required=True,
+        help="e.g. strategies.sentient_spire_v12:SentientSpireV12",
+    )
     ap.add_argument("--report", required=True, type=Path, help="Output JSON path")
     args = ap.parse_args()
 
@@ -23,6 +36,7 @@ def main() -> None:
     args.report.parent.mkdir(parents=True, exist_ok=True)
     args.report.write_text(json.dumps(result, indent=2))
     print(f"✅ wrote {args.report}")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/run_mc.py
+++ b/scripts/run_mc.py
@@ -1,19 +1,32 @@
 # scripts/run_mc.py
 from __future__ import annotations
+
 import argparse
 import importlib
 import json
 from pathlib import Path
+
 import pandas as pd
+
 from sim.monte_carlo import run_mc
+
 
 def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--bars", required=True, type=Path)
-    ap.add_argument("--strategy", required=True, help="e.g. strategies.sentient_spire_v12:SentientSpireV12")
+    ap.add_argument(
+        "--strategy",
+        required=True,
+        help="e.g. strategies.sentient_spire_v12:SentientSpireV12",
+    )
     ap.add_argument("--runs", type=int, default=200)
     ap.add_argument("--seed", type=int, default=42)
-    ap.add_argument("--price_bps", type=float, default=0.0, help="Gaussian price jitter sigma in bps")
+    ap.add_argument(
+        "--price_bps",
+        type=float,
+        default=0.0,
+        help="Gaussian price jitter sigma in bps",
+    )
     ap.add_argument("--slippage_ticks", type=float, default=1.0)
     ap.add_argument("--report", required=True, type=Path)
     args = ap.parse_args()
@@ -21,13 +34,22 @@ def main() -> None:
     df = pd.read_csv(args.bars)
     mod, cls = args.strategy.split(":")
     Strat = getattr(importlib.import_module(mod), cls)
+
     def ctor():
         return Strat()
 
-    summary = run_mc(df, ctor, runs=args.runs, seed=args.seed, price_bps=args.price_bps, slippage_ticks=args.slippage_ticks)
+    summary = run_mc(
+        df,
+        ctor,
+        runs=args.runs,
+        seed=args.seed,
+        price_bps=args.price_bps,
+        slippage_ticks=args.slippage_ticks,
+    )
     args.report.parent.mkdir(parents=True, exist_ok=True)
     args.report.write_text(json.dumps(summary, indent=2))
     print(f"✅ wrote {args.report}")
+
 
 if __name__ == "__main__":
     main()

--- a/sim/metrics.py
+++ b/sim/metrics.py
@@ -1,7 +1,9 @@
 # sim/metrics.py
 from __future__ import annotations
+
 import numpy as np
 import pandas as pd
+
 
 def daily_roi_df(equity: pd.Series) -> pd.DataFrame:
     eq = equity.dropna()
@@ -12,6 +14,7 @@ def daily_roi_df(equity: pd.Series) -> pd.DataFrame:
     pnl = daily.diff().fillna(0.0)
     return pd.DataFrame({"date": daily.index.date, "roi_pct": roi.values, "pnl": pnl.values})
 
+
 def max_drawdown_pct(equity: pd.Series) -> float:
     eq = equity.dropna()
     if eq.empty:
@@ -20,12 +23,14 @@ def max_drawdown_pct(equity: pd.Series) -> float:
     dd = (eq / run_max - 1.0).min()
     return float(abs(dd) * 100.0)
 
+
 def sharpe_daily(equity: pd.Series, rf: float = 0.0) -> float:
     ret = equity.pct_change().dropna()
     if ret.std() == 0 or ret.empty:
         return 0.0
     ex = ret - rf / 252.0
     return float(np.sqrt(252) * ex.mean() / ex.std())
+
 
 def calmar(equity: pd.Series) -> float:
     eq = equity.dropna()
@@ -36,6 +41,7 @@ def calmar(equity: pd.Series) -> float:
     cagr = (1.0 + total_ret) ** (1.0 / years) - 1.0 if years > 0 else 0.0
     mdd = max_drawdown_pct(eq) / 100.0
     return 0.0 if mdd == 0 else float(cagr / mdd)
+
 
 def equity_stats(equity: pd.Series) -> dict:
     daily = daily_roi_df(equity)

--- a/sim/monte_carlo.py
+++ b/sim/monte_carlo.py
@@ -1,11 +1,19 @@
 # sim/monte_carlo.py
 from __future__ import annotations
-from typing import Callable
+
+from collections.abc import Callable
+
 import numpy as np
 import pandas as pd
+
 from .engine import run_once
 
-def perturb_bars(bars: pd.DataFrame, rng: np.random.Generator, price_bps: float = 0.0) -> pd.DataFrame:
+
+def perturb_bars(
+    bars: pd.DataFrame,
+    rng: np.random.Generator,
+    price_bps: float = 0.0,
+) -> pd.DataFrame:
     if price_bps <= 0:
         return bars
     jitter = 1.0 + rng.normal(0.0, price_bps / 10_000.0, size=len(bars))
@@ -13,6 +21,7 @@ def perturb_bars(bars: pd.DataFrame, rng: np.random.Generator, price_bps: float 
     for col in ("open", "high", "low", "close"):
         df[col] = (df[col].to_numpy() * jitter).astype(float)
     return df
+
 
 def run_mc(
     bars: pd.DataFrame,

--- a/strategies/base.py
+++ b/strategies/base.py
@@ -1,21 +1,24 @@
 # strategies/base.py
 from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Optional, List, Dict, Any
+from typing import Any
+
 
 @dataclass
 class Context:
     cash: float
     position_qty: int
-    position_avg: Optional[float]
+    position_avg: float | None
     day_pnl: float
     realized_dd_pct: float
     regime: str
 
+
 class Strategy:
     name = "BaseStrategy"
 
-    def on_bar(self, bar_row: Any, ctx: Context) -> List[Dict[str, Any]]:
+    def on_bar(self, bar_row: Any, ctx: Context) -> list[dict[str, Any]]:
         """
         Return a list of order dicts:
           {'side': 'BUY'|'SELL', 'qty': int}

--- a/strategies/sentient_spire_v12.py
+++ b/strategies/sentient_spire_v12.py
@@ -1,7 +1,10 @@
 # strategies/sentient_spire_v12.py
 from __future__ import annotations
-from typing import List, Dict, Any
-from .base import Strategy, Context
+
+from typing import Any
+
+from .base import Context, Strategy
+
 
 class SentientSpireV12(Strategy):
     """
@@ -10,6 +13,7 @@ class SentientSpireV12(Strategy):
     - Exit when RSI<45 or regime turns 'Cascade'
     - Risk % sizing against ATR stop distance
     """
+
     name = "SentientSpire_v12"
 
     def __init__(self, risk_pct: float = 0.015, stop_atr_mult: float = 1.5, target_r: float = 2.2):
@@ -17,24 +21,25 @@ class SentientSpireV12(Strategy):
         self.stop_atr_mult = stop_atr_mult
         self.target_r = target_r
 
-    def on_bar(self, bar_row, ctx: Context) -> List[Dict[str, Any]]:
+    def on_bar(self, bar_row, ctx: Context) -> list[dict[str, Any]]:
+        close = float(bar_row["close"])
+
         if ctx.regime == "Cascade":
             # de-risk: exit if in market
             if ctx.position_qty > 0:
-                return [{"side": "SELL", "qty": ctx.position_qty}]
+                return [{"side": "SELL", "qty": ctx.position_qty, "price_hint": close}]
             return []
 
         ema_fast = float(bar_row.get("ema_fast", 0))
         ema_slow = float(bar_row.get("ema_slow", 0))
         rsi = float(bar_row.get("rsi", 50))
         atr = float(bar_row.get("atr", 0.5))
-        close = float(bar_row["close"])
 
-        orders: List[Dict[str, Any]] = []
+        orders: list[dict[str, Any]] = []
 
         # Exit rule
         if ctx.position_qty > 0 and rsi < 45:
-            orders.append({"side": "SELL", "qty": ctx.position_qty})
+            orders.append({"side": "SELL", "qty": ctx.position_qty, "price_hint": close})
             return orders
 
         # Entry rule
@@ -46,7 +51,7 @@ class SentientSpireV12(Strategy):
             risk_cash = ctx.cash * self.risk_pct
             qty = int(max(1, risk_cash / (stop_dist_px * dollar_per_point)))
             if qty > 0:
-                orders.append({"side": "BUY", "qty": qty})
+                orders.append({"side": "BUY", "qty": qty, "price_hint": close})
 
         return orders
 


### PR DESCRIPTION
## Summary
- switch strategy base classes to use built-in collection generics and modern Optional syntax
- update SentientSpire demo strategy to consume the close price via price hints while keeping Ruff happy
- clean up sim utilities and CLI helpers to satisfy Ruff/Black style requirements

## Testing
- `ruff check . --fix`
- `black --check .`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68cdb0ae55bc832090ed1e28086ba05e